### PR TITLE
Don’t use weak reference in Facebook network.

### DIFF
--- a/facebook/src/main/java/com/jetradarmobile/sociallogin/facebook/FacebookNetwork.kt
+++ b/facebook/src/main/java/com/jetradarmobile/sociallogin/facebook/FacebookNetwork.kt
@@ -14,11 +14,11 @@ import java.lang.ref.WeakReference
 
 class FacebookNetwork(val permissions: List<String>) : SocialNetwork, FacebookCallback<LoginResult> {
 
-    private var loginCallback: WeakReference<SocialLoginCallback>? = null
+    private var loginCallback: SocialLoginCallback? = null
     private val callbackManager = CallbackManager.Factory.create()
 
     override fun login(activity: Activity, callback: SocialLoginCallback) {
-        this.loginCallback = WeakReference(callback)
+        this.loginCallback = callback
 
         LoginManager.getInstance().registerCallback(callbackManager, this)
 
@@ -29,7 +29,7 @@ class FacebookNetwork(val permissions: List<String>) : SocialNetwork, FacebookCa
             LoginManager.getInstance().logInWithReadPermissions(activity, permissions)
         } else {
             val socialToken = createSocialToken(token, profile)
-            loginCallback?.get()?.onLoginSuccess(this, socialToken)
+            loginCallback?.onLoginSuccess(this, socialToken)
         }
     }
 
@@ -42,7 +42,7 @@ class FacebookNetwork(val permissions: List<String>) : SocialNetwork, FacebookCa
     }
 
     override fun onCancel() {
-        loginCallback?.get()?.onLoginError(this, FacebookLoginError(SocialLoginError.Reason.CANCEL))
+        loginCallback?.onLoginError(this, FacebookLoginError(SocialLoginError.Reason.CANCEL))
     }
 
     override fun onSuccess(result: LoginResult?) {
@@ -51,14 +51,14 @@ class FacebookNetwork(val permissions: List<String>) : SocialNetwork, FacebookCa
 
         if (token != null) {
             val socialToken = createSocialToken(token, profile)
-            loginCallback?.get()?.onLoginSuccess(this, socialToken)
+            loginCallback?.onLoginSuccess(this, socialToken)
         } else {
-            loginCallback?.get()?.onLoginError(this, FacebookLoginError(FacebookLoginError.NO_LOGIN))
+            loginCallback?.onLoginError(this, FacebookLoginError(FacebookLoginError.NO_LOGIN))
         }
     }
 
     override fun onError(error: FacebookException?) {
-        loginCallback?.get()?.onLoginError(this,
+        loginCallback?.onLoginError(this,
                 FacebookLoginError(error?.localizedMessage ?: "Facebook login error"))
     }
 


### PR DESCRIPTION
Fixes #4 
When you start login and there is no cached token, library starts login process.
By then, the only strong reference to the callback object is a local variable which will then be out-of-scope. This causes the referent to be GC-d ( no strong references to the object).

When the login is either finished or canceled, the library tried to send invoke the callback, but the get() of WeakReference returns null, and no callback is called. This means that on the API side, neither onNext or onError is called anymore.